### PR TITLE
Running MFC out-of-core on NVIDIA Grace-Hopper using Unified Memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,11 +501,11 @@ function(MFC_SETUP_TARGET)
                 # GH-200 Unified Memory Support
                 if (MFC_Unified)
                     target_compile_options(${ARGS_TARGET}
-                        PRIVATE -gpu=unified
+                        PRIVATE -gpu=mem:unified -cuda
                     )
                     # "This option must appear in both the compile and link lines" -- NVHPC Docs
                     target_link_options(${ARGS_TARGET}
-                        PRIVATE -gpu=unified
+                        PRIVATE -gpu=mem:unified -cuda
                     )
                 endif()
 

--- a/examples/3D_IGR_perf_test/case.py
+++ b/examples/3D_IGR_perf_test/case.py
@@ -43,6 +43,7 @@ eps = 1e-5
 
 # Configuring case dictionary
 case = {
+        "rdma_mpi": "T",
         # Logistics
         # "run_time_info": "T",
         # Computational Domain Parameters

--- a/misc/nvidia_uvm/README.md
+++ b/misc/nvidia_uvm/README.md
@@ -39,7 +39,10 @@ cd MFC-Wilfong
 export MFC_CUDA_CC=90
 ./mfc.sh build --gpu -j 71 --single --unified --verbose
 
-# Run pre_process and simulation binaries with case optimization
+# Run pre_process and simulation binaries with case optimization (in an interactive job)
 ./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --gpu -N 1 -n 4 -j 71 -c santis
+
+# Run pre_process and simulation binaries with case optimization (in an batch job)
+./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --gpu -N 1 -n 4 -j 71 -c santis -e batch -p normal -a g183 -w 00:15:00
 ```
 The environment variables `NVIDIA_ALLOC_MODE`, `NVIDIA_MANUAL_GPU_HINTS`, `NVIDIA_VARS_ON_GPU`, and `NVIDIA_IGR_TEMPS_ON_GPU`, can be set appropriately in `toolchain/templates/santis.mako`, to configure a run with ALL buffers either in GPU or in CPU memory, or a run with SOME buffers in GPU memory and the rest in CPU memory.

--- a/misc/nvidia_uvm/README.md
+++ b/misc/nvidia_uvm/README.md
@@ -42,4 +42,4 @@ export MFC_CUDA_CC=90
 # Run pre_process and simulation binaries with case optimization
 ./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --gpu -N 1 -n 4 -j 71 -c santis
 ```
-The environment variables `NVIDIA_ALLOC_MODE`, `NVIDIA_MANUAL_GPU_HINTS`, and `NVIDIA_VARS_ON_GPU`, can be set appropriately in `toolchain/templates/santis.mako`.
+The environment variables `NVIDIA_ALLOC_MODE`, `NVIDIA_MANUAL_GPU_HINTS`, `NVIDIA_VARS_ON_GPU`, and `NVIDIA_IGR_TEMPS_ON_GPU`, can be set appropriately in `toolchain/templates/santis.mako`, to configure a run with ALL buffers either in GPU or in CPU memory, or a run with SOME buffers in GPU memory and the rest in CPU memory.

--- a/misc/nvidia_uvm/README.md
+++ b/misc/nvidia_uvm/README.md
@@ -1,0 +1,33 @@
+## Example Workflow for NVIDIA Out-of-Core Strategy based on Unified Memory
+
+```shell
+# Allocate a node
+salloc -A g183 --partition normal -t 02:00:00 -N 1 -n 4 --cpus-per-task=71
+
+# Start uenv
+uenv start --view=modules icon/25.2:v1
+
+# cd to root directory of MFC
+cd MFC-Wilfong
+
+# Load modules
+. ./mfc.sh load -c san -m g
+
+# Build
+export MFC_CUDA_CC=90
+./mfc.sh build --gpu -j $(nproc) --single --unified --verbose
+
+# Dry mfc run to compile preprocess and simulation binaries with case optimization
+./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --dry-run --gpu -N 1 -n 4 -j 71
+
+# Run preprocess
+./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process --gpu -N 1 -n 4 -j 71
+
+# cd to case dir
+cd examples/3D_IGR_perf_test/
+
+# run with env vars set, with binding script, and with nsys script
+bash run.sh
+```
+The example `bind.sh`, `nsys.sh`, and `run.sh` I used can be found here under `misc/nvidia_uvm`.
+These should be incorporated to the python based mfc workflow.

--- a/misc/nvidia_uvm/README.md
+++ b/misc/nvidia_uvm/README.md
@@ -37,20 +37,9 @@ cd MFC-Wilfong
 
 # Build
 export MFC_CUDA_CC=90
-./mfc.sh build --gpu -j $(nproc) --single --unified --verbose
+./mfc.sh build --gpu -j 71 --single --unified --verbose
 
-# Dry mfc run to compile pre_process and simulation binaries with case optimization
-./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --dry-run --gpu -N 1 -n 4 -j 71 -c santis
-
-# Run pre_process
-./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process --gpu -N 1 -n 4 -j 71 -c santis
-
-# cd to case dir
-cd examples/3D_IGR_perf_test/
-
-# Run simulation with env vars set, with binding script, and with nsys script
-bash run.sh
+# Run pre_process and simulation binaries with case optimization
+./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --gpu -N 1 -n 4 -j 71 -c santis
 ```
-The example `bind.sh`, `nsys.sh`, and `run.sh` I used can be found here under `misc/nvidia_uvm`.
-These should be incorporated to the python based mfc workflow.
-
+The environment variables `NVIDIA_ALLOC_MODE`, `NVIDIA_MANUAL_GPU_HINTS`, and `NVIDIA_VARS_ON_GPU`, can be set appropriately in `toolchain/templates/santis.mako`.

--- a/misc/nvidia_uvm/README.md
+++ b/misc/nvidia_uvm/README.md
@@ -39,16 +39,16 @@ cd MFC-Wilfong
 export MFC_CUDA_CC=90
 ./mfc.sh build --gpu -j $(nproc) --single --unified --verbose
 
-# Dry mfc run to compile preprocess and simulation binaries with case optimization
-./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --dry-run --gpu -N 1 -n 4 -j 71
+# Dry mfc run to compile pre_process and simulation binaries with case optimization
+./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process simulation --dry-run --gpu -N 1 -n 4 -j 71 -c santis
 
-# Run preprocess
-./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process --gpu -N 1 -n 4 -j 71
+# Run pre_process
+./mfc.sh run examples/3D_IGR_perf_test/case.py --case-optimization -t pre_process --gpu -N 1 -n 4 -j 71 -c santis
 
 # cd to case dir
 cd examples/3D_IGR_perf_test/
 
-# Run with env vars set, with binding script, and with nsys script
+# Run simulation with env vars set, with binding script, and with nsys script
 bash run.sh
 ```
 The example `bind.sh`, `nsys.sh`, and `run.sh` I used can be found here under `misc/nvidia_uvm`.

--- a/misc/nvidia_uvm/README.md
+++ b/misc/nvidia_uvm/README.md
@@ -1,3 +1,25 @@
+## The Main Idea behind the implemented Out-of-Core Strategy for NVIDIA Grace-Hopper
+
+To run MFC out-of-core on Grace-Hopper using Unified Memory we implement a zero-copy strategy.
+
+We start by setting preferred location CPU for all buffers by hooking into the allocate macro and setting `NVIDIA_ALLOC_MODE=2`.
+This way we disable access counter based migrations and keep everything on the CPU memory, freeing up as much GPU memory as possible.
+
+Then, for the "important" buffers that are frequently accessed from the GPU, we reset preferred location to GPU in order to place them (and directly populate them) in GPU memory.
+This is done by the `PREFER_GPU` macro that has been manually placed in the code right after the allocations of the "important" buffers.
+To activate these hints we export `NVIDIA_MANUAL_GPU_HINTS=1`.
+
+To allow fine grained control and be able to simulate larger sizes, we also use the following environment variables:
+- With `NVIDIA_IGR_TEMPS_ON_GPU` we control how many temporaries from the IGR module are to be placed in GPU memory.
+- With `NVIDIA_VARS_ON_GPU` we control how many of the `q_cons_ts(1)%vf(j)%sf` arrays we place in GPU memory.
+
+It is important to note that we have rearranged the timestep updates in the 3rd order TVD Runge Kutta scheme in a way that allows us to pass only `q_cons_ts(1)` to the `compute_rhs` routines.
+This way, in order to keep the computation of `compute_rhs` (mostly) on GPU data, we only need to store `q_cons_ts(1)` (fully or even partially) in GPU memory.
+Thus, we choose to keep `q_cons_ts(2)` in CPU memory for the full lifetime of the simulation, freeing up space in GPU memory that allows for bumping up the size of the simulation, without sacrificing performance.
+In the timestep updates between the `compute_rhs` calls, we access both `q_cons_ts(1)` and `q_cons_ts(2)` directly from the physical location where they reside (zero-copy), simultaneously pulling data from GPU memory and CPU memory (through C2C), making good use of Grace-Hopper.
+
+Note: This rearrangement most likely "breaks" the timestepper for different physics cases, but we can easily fix it in a later step.
+
 ## Example Workflow for NVIDIA Out-of-Core Strategy based on Unified Memory
 
 ```shell
@@ -32,21 +54,3 @@ bash run.sh
 The example `bind.sh`, `nsys.sh`, and `run.sh` I used can be found here under `misc/nvidia_uvm`.
 These should be incorporated to the python based mfc workflow.
 
-## The Main Idea behind the Implemented Out-of-Core Strategy
-
-To run MFC out-of-core on Grace Hopper using Unified Memory we implement a zero-copy strategy.
-
-We start by setting preferred location CPU for all buffers by hooking into the allocate macro and setting `NVIDIA_ALLOC_MODE=2`.
-This way we disable access counter based migrations and keep everything on the CPU memory, freeing up as much GPU memory as possible.
-
-Then, for the "important" buffers that are frequently accessed from the GPU, we reset preferred location to GPU in order to place them to GPU memory.
-This is done by the `PREFER_GPU` macro that has been manually placed in the code right after the allocations of the "important" buffers.
-To activate these we export `NVIDIA_MANUAL_GPU_HINTS=1`.
-
-To allow fine grained control and be able to simulate larger sizes, we also use the following environment variables:
-- With `NVIDIA_IGR_TEMPS_ON_GPU` we control how many temporaries from the IGR module are to be placed in GPU memory.
-- With `NVIDIA_VARS_ON_GPU` we control how many of the `q_cons_ts(1)%vf(j)%sf` arrays we place in GPU memory.
-
-It is important to note that we have rearranged the timestep updates in the runge kutta scheme, in a way that allows us to pass only `q_cons_ts(1)` to the `compute_rhs` routines and keep `q_cons_ts(2)` on the CPU for the full lifetime of the simulation, without sacrificing performance.
-
-Note: This rearrangement may be "breaking" the timestepper for different configurations, but we can easily fix it in a later step.

--- a/misc/nvidia_uvm/bind.sh
+++ b/misc/nvidia_uvm/bind.sh
@@ -15,6 +15,7 @@ export MPICH_OFI_NIC_POLICY=USER
 export MPICH_OFI_NIC_MAPPING="0:0; 1:1; 2:2; 3:3"
 
 # Bind to cores ( second core per socket )
+# see https://eth-cscs.github.io/cscs-docs/guides/gb2025/#low-noise-mode
 physcores=(1 73 145 217)
 
 #echo rank: $local_rank, cores: ${physcores[$local_rank]}, GPU: $CUDA_VISIBLE_DEVICES, NIC mapping: $MPICH_OFI_NIC_POLICY

--- a/misc/nvidia_uvm/bind.sh
+++ b/misc/nvidia_uvm/bind.sh
@@ -17,8 +17,8 @@ export MPICH_OFI_NIC_MAPPING="0:0; 1:1; 2:2; 3:3"
 # Bind to cores ( second core per socket )
 physcores=(1 73 145 217)
 
-echo rank: $local_rank, cores: ${physcores[$local_rank]}, GPU: $CUDA_VISIBLE_DEVICES, NIC mapping: $MPICH_OFI_NIC_POLICY
+#echo rank: $local_rank, cores: ${physcores[$local_rank]}, GPU: $CUDA_VISIBLE_DEVICES, NIC mapping: $MPICH_OFI_NIC_POLICY
 
-set -x
+#set -x
 numactl -l --all --physcpubind=${physcores[$local_rank]} "$@"
-set +x
+#set +x

--- a/misc/nvidia_uvm/bind.sh
+++ b/misc/nvidia_uvm/bind.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# -------------------------------- #
+# Binding for a single Santis node #
+# -------------------------------- #
+
+# Local rank
+export local_rank="${OMPI_COMM_WORLD_LOCAL_RANK:-$SLURM_LOCALID}"
+
+# Bind to GPU
+export CUDA_VISIBLE_DEVICES="$local_rank"
+
+# Binding to NIC
+export MPICH_OFI_NIC_POLICY=USER
+export MPICH_OFI_NIC_MAPPING="0:0; 1:1; 2:2; 3:3"
+
+# Bind to cores ( second core per socket )
+physcores=(1 73 145 217)
+
+echo rank: $local_rank, cores: ${physcores[$local_rank]}, GPU: $CUDA_VISIBLE_DEVICES, NIC mapping: $MPICH_OFI_NIC_POLICY
+
+set -x
+numactl -l --all --physcpubind=${physcores[$local_rank]} "$@"
+set +x

--- a/misc/nvidia_uvm/nsys.sh
+++ b/misc/nvidia_uvm/nsys.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+#set -x
 set -euo pipefail
 
 rank="${OMPI_COMM_WORLD_RANK:-$SLURM_PROCID}"

--- a/misc/nvidia_uvm/nsys.sh
+++ b/misc/nvidia_uvm/nsys.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+rank="${OMPI_COMM_WORLD_RANK:-$SLURM_PROCID}"
+
+[[ -z "${NSYS_FILE+x}" ]] && NSYS_FILE=report.qdrep
+[[ -z "${NSYS+x}" ]] && NSYS=0
+
+if [[ "$NSYS" -ne 0 && "$rank" -eq 0 ]]; then
+  exec nsys profile \
+      --cuda-um-cpu-page-faults true \
+      --cuda-um-gpu-page-faults true \
+      --event-sample=system-wide \
+      --cpu-socket-events=61,71,265,273 \
+      --cpu-socket-metrics=103,104 \
+      --event-sampling-interval=1 \
+      --trace=nvtx,openacc \
+      --force-overwrite=true \
+      -e NSYS_MPI_STORE_TEAMS_PER_RANK=1 \
+      -o "$NSYS_FILE" "$@"
+else
+  exec "$@"
+fi

--- a/misc/nvidia_uvm/run.sh
+++ b/misc/nvidia_uvm/run.sh
@@ -21,7 +21,7 @@ export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on 
 
 # NSYS
 export NSYS=1                                 # enable nsys profiling
-export NSYS_FILE=report_uvm_single_N-499-nGPUs-4_params-${NVIDIA_VARS_ON_GPU}-${NVIDIA_IGR_TEMPS_ON_GPU}.qdrep
+export NSYS_FILE=report_uvm_single_N-499_nGPUs-4_params-${NVIDIA_VARS_ON_GPU}-${NVIDIA_IGR_TEMPS_ON_GPU}.qdrep
 
 # Run using --cpu-bind=none because we use our own binding script
 srun --ntasks 4 --cpu-bind=none ./nsys.sh ./bind.sh ${PATH_TO_BINARY}/simulation

--- a/misc/nvidia_uvm/run.sh
+++ b/misc/nvidia_uvm/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# TODO: Modify accordingly
+PATH_TO_BINARY=${SCRATCH}/projects/cfd/mfc/MFC-Wilfong/build/install/cdcd4e8762/bin/
+
+# NVHPC and CUDA env vars
+export NV_ACC_USE_MALLOC=1                    # use malloc instead of cudaMallocManaged ( compiled using -gpu=mem:unified )
+export NVCOMPILER_ACC_NO_MEMHINTS=1           # disable implicit compiler hints
+export CUDA_BUFFER_PAGE_IN_THRESHOLD_MS=0.001 # workaround for copying to/from unpopulated buffers on GH
+
+# Cray MPICH
+export MPICH_GPU_SUPPORT_ENABLED=1            # MPICH with GPU support
+export FI_CXI_RX_MATCH_MODE=software
+export FI_MR_CACHE_MONITOR=disabled
+
+# CUSTOM env vars to MFC
+export NVIDIA_ALLOC_MODE=2                    # default alloc to prefloc CPU
+export NVIDIA_MANUAL_GPU_HINTS=1              # prefloc GPU on some
+export NVIDIA_IGR_TEMPS_ON_GPU=1              # jac on GPU and jac_rhs on CPU       ( NOTE: good default, tune based on size )
+export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on GPU ( NOTE: good default, tune based on size )
+
+# NSYS
+export NSYS=1                                 # enable nsys profiling
+export NSYS_FILE=report_uvm_single_N-499-nGPUs-4_params-${NVIDIA_VARS_ON_GPU}-${NVIDIA_IGR_TEMPS_ON_GPU}.qdrep
+
+# Run using --cpu-bind=none because we use our own binding script
+srun --ntasks 4 --cpu-bind=none ./nsys.sh ./bind.sh ${PATH_TO_BINARY}/simulation

--- a/src/common/include/macros.fpp
+++ b/src/common/include/macros.fpp
@@ -31,7 +31,7 @@
 
     if (prefer_gpu_mode .eq. 1) then
     #:for arg in args
-        print*, "Moving ${arg}$ to GPU => ", SHAPE(${arg}$)
+        !print*, "Moving ${arg}$ to GPU => ", SHAPE(${arg}$)
         ! unset
         istat = cudaMemAdvise( c_devloc(${arg}$), SIZEOF(${arg}$), cudaMemAdviseUnSetPreferredLocation, cudaCpuDeviceId )
         if (istat /= cudaSuccess) then

--- a/src/common/include/macros.fpp
+++ b/src/common/include/macros.fpp
@@ -10,10 +10,107 @@
 #endif
 #:enddef
 
+#:def PREFER_GPU(*args)
+#ifdef MFC_SIMULATION
+#ifdef __NVCOMPILER_GPU_UNIFIED_MEM
+    block
+    use cudafor, gpu_sum => sum, gpu_maxval => maxval, gpu_minval => minval
+    integer :: istat
+    integer :: prefer_gpu_mode
+    character(len=10) :: prefer_gpu_mode_str
+
+    ! environment variable
+    call get_environment_variable("NVIDIA_MANUAL_GPU_HINTS", prefer_gpu_mode_str)
+    if (trim(prefer_gpu_mode_str) == "0") then ! OFF
+        prefer_gpu_mode = 0
+    elseif (trim(prefer_gpu_mode_str) == "1") then ! ON
+        prefer_gpu_mode = 1
+    else ! default
+        prefer_gpu_mode = 0
+    endif
+
+    if (prefer_gpu_mode .eq. 1) then
+    #:for arg in args
+        print*, "Moving ${arg}$ to GPU => ", SHAPE(${arg}$)
+        ! unset
+        istat = cudaMemAdvise( c_devloc(${arg}$), SIZEOF(${arg}$), cudaMemAdviseUnSetPreferredLocation, cudaCpuDeviceId )
+        if (istat /= cudaSuccess) then
+            write(*,"('Error code: ',I0, ': ')") istat
+            write(*,*) cudaGetErrorString(istat)
+        endif
+        ! set
+        istat = cudaMemAdvise( c_devloc(${arg}$), SIZEOF(${arg}$), cudaMemAdviseSetPreferredLocation, 0 )
+        if (istat /= cudaSuccess) then
+            write(*,"('Error code: ',I0, ': ')") istat
+            write(*,*) cudaGetErrorString(istat)
+        endif
+    #:endfor
+    end if
+    end block
+#endif
+#endif
+#:enddef
+
+#:def PARSE(s)
+${s if s.rfind(')') == -1 else next((s[:i] for i in range(s.rfind(')'), -1, -1) if s[i] == '(' and s.count('(', i, s.rfind(')')+1) == s.count(')', i, s.rfind(')')+1)), s)}$
+#:enddef
+
 #:def ALLOCATE(*args)
     @:LOG({'@:ALLOCATE(${re.sub(' +', ' ', ', '.join(args))}$)'})
     allocate (${', '.join(args)}$)
     !$acc enter data create(${', '.join(args)}$)
+
+#ifdef MFC_SIMULATION
+#ifdef __NVCOMPILER_GPU_UNIFIED_MEM
+    block
+    use cudafor, gpu_sum => sum, gpu_maxval => maxval, gpu_minval => minval
+    integer :: istat, stream_id
+    integer :: alloc_mode
+    character(len=10) :: alloc_mode_str
+
+    ! environment variable
+    call get_environment_variable("NVIDIA_ALLOC_MODE", alloc_mode_str)
+    if (trim(alloc_mode_str) == "0") then ! no CPU first touch, no preferred location CPU
+        alloc_mode = 0
+    elseif (trim(alloc_mode_str) == "1") then ! CPU first touch, no preferred location CPU
+        alloc_mode = 1
+    elseif (trim(alloc_mode_str) == "2") then ! no CPU first touch, preferred location CPU
+        alloc_mode = 2
+    elseif (trim(alloc_mode_str) == "3") then ! CPU first touch, preferred location CPU
+        alloc_mode = 3
+    else ! default
+        alloc_mode = 0
+    endif
+
+    stream_id = 0
+
+    ! prefetch to CPU
+    if ((alloc_mode .eq. 1) .or. (alloc_mode .eq. 3)) then
+    #:for arg in args
+        istat = cudaMemPrefetchAsync( c_devloc(@{PARSE(${arg}$)}@), SIZEOF(@{PARSE(${arg}$)}@), cudaCpuDeviceId, stream_id )
+        print*, "! @{PARSE(${arg}$)}@ with shape",  SHAPE(@{PARSE(${arg}$)}@), "=> prefetch to CPU"
+        if (istat /= cudaSuccess) then
+            write(*,"('Error code: ',I0, ': ')") istat
+            write(*,*) cudaGetErrorString(istat)
+        endif
+    #:endfor
+    endif
+
+    ! memadvise preferred location
+    if ((alloc_mode .eq. 2) .or. (alloc_mode .eq. 3)) then
+    #:for arg in args
+        istat = cudaMemAdvise( c_devloc(@{PARSE(${arg}$)}@), SIZEOF(@{PARSE(${arg}$)}@), cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId )
+        print*, "! @{PARSE(${arg}$)}@ with shape",  SHAPE(@{PARSE(${arg}$)}@), "=> preferred location CPU"
+        if (istat /= cudaSuccess) then
+            write(*,"('Error code: ',I0, ': ')") istat
+            write(*,*) cudaGetErrorString(istat)
+        endif
+    #:endfor
+    endif
+
+    end block
+#endif
+#endif
 #:enddef ALLOCATE
 
 #:def DEALLOCATE(*args)

--- a/src/common/include/macros.fpp
+++ b/src/common/include/macros.fpp
@@ -88,7 +88,7 @@ ${s if s.rfind(')') == -1 else next((s[:i] for i in range(s.rfind(')'), -1, -1) 
     if ((alloc_mode .eq. 1) .or. (alloc_mode .eq. 3)) then
     #:for arg in args
         istat = cudaMemPrefetchAsync( c_devloc(@{PARSE(${arg}$)}@), SIZEOF(@{PARSE(${arg}$)}@), cudaCpuDeviceId, stream_id )
-        print*, "! @{PARSE(${arg}$)}@ with shape",  SHAPE(@{PARSE(${arg}$)}@), "=> prefetch to CPU"
+        !print*, "! @{PARSE(${arg}$)}@ with shape",  SHAPE(@{PARSE(${arg}$)}@), "=> prefetch to CPU"
         if (istat /= cudaSuccess) then
             write(*,"('Error code: ',I0, ': ')") istat
             write(*,*) cudaGetErrorString(istat)
@@ -100,7 +100,7 @@ ${s if s.rfind(')') == -1 else next((s[:i] for i in range(s.rfind(')'), -1, -1) 
     if ((alloc_mode .eq. 2) .or. (alloc_mode .eq. 3)) then
     #:for arg in args
         istat = cudaMemAdvise( c_devloc(@{PARSE(${arg}$)}@), SIZEOF(@{PARSE(${arg}$)}@), cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId )
-        print*, "! @{PARSE(${arg}$)}@ with shape",  SHAPE(@{PARSE(${arg}$)}@), "=> preferred location CPU"
+        !print*, "! @{PARSE(${arg}$)}@ with shape",  SHAPE(@{PARSE(${arg}$)}@), "=> preferred location CPU"
         if (istat /= cudaSuccess) then
             write(*,"('Error code: ',I0, ': ')") istat
             write(*,*) cudaGetErrorString(istat)

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -1232,16 +1232,25 @@ contains
         @:ALLOCATE(x_cb(-1 - buff_size:m + buff_size))
         @:ALLOCATE(x_cc(-buff_size:m + buff_size))
         @:ALLOCATE(dx(-buff_size:m + buff_size))
+        @:PREFER_GPU(x_cb)
+        @:PREFER_GPU(x_cc)
+        @:PREFER_GPU(dx)
 
         if (n == 0) return; 
         @:ALLOCATE(y_cb(-1 - buff_size:n + buff_size))
         @:ALLOCATE(y_cc(-buff_size:n + buff_size))
         @:ALLOCATE(dy(-buff_size:n + buff_size))
+        @:PREFER_GPU(y_cb)
+        @:PREFER_GPU(y_cc)
+        @:PREFER_GPU(dy)
 
         if (p == 0) return; 
         @:ALLOCATE(z_cb(-1 - buff_size:p + buff_size))
         @:ALLOCATE(z_cc(-buff_size:p + buff_size))
         @:ALLOCATE(dz(-buff_size:p + buff_size))
+        @:PREFER_GPU(z_cb)
+        @:PREFER_GPU(z_cc)
+        @:PREFER_GPU(dz)
 
     end subroutine s_initialize_global_parameters_module
 

--- a/src/simulation/m_igr.fpp
+++ b/src/simulation/m_igr.fpp
@@ -68,6 +68,8 @@ contains
                 end do
             end do
             !$acc update device(Res, Re_idx, Re_size)
+            @:PREFER_GPU(Res)
+            @:PREFER_GPU(Re_idx)
         end if
 
         if(igr) then 
@@ -76,6 +78,8 @@ contains
                              idwbuff(2)%beg:idwbuff(2)%end, &
                              idwbuff(3)%beg:idwbuff(3)%end))
             #:endfor
+            @:PREFER_GPU(jac)
+            @:PREFER_GPU(jac_rhs)
 
             !$acc parallel loop collapse(3) gang vector default(present)
             do l = idwbuff(3)%beg, idwbuff(3)%end

--- a/src/simulation/m_igr.fpp
+++ b/src/simulation/m_igr.fpp
@@ -33,8 +33,22 @@ module m_igr
     real(wp), allocatable, dimension(:, :) :: Res
     !$acc declare create(Res)
 
-    real(wp), allocatable, dimension(:) :: coeff_L, coeff_R
-    !$acc declare create(coeff_L, coeff_R)
+
+    real(wp), parameter :: coeff_L(-1:3) = [ &
+        -3._wp/60._wp,   &  ! Index -1
+        27._wp/60._wp,   &  ! Index 0
+        47._wp/60._wp,   &  ! Index 1
+        -13._wp/60._wp,  &  ! Index 2
+        2._wp/60._wp     &  ! Index 3
+        ]
+
+    real(wp), parameter :: coeff_R(-2:2) = [ &
+        2._wp/60._wp,    &  ! Index -2
+        -13._wp/60._wp,  &  ! Index -1
+        47._wp/60._wp,   &  ! Index 0
+        27._wp/60._wp,   &  ! Index 1
+        -3._wp/60._wp    &  ! Index 2
+        ]
 
     integer :: i, j, k, l, q, r
 
@@ -72,22 +86,6 @@ contains
                 end do
             end do
 
-
-            @:ALLOCATE(coeff_L(-1:3))
-            coeff_L(-1) = (-3._wp/60._wp)
-            coeff_L(0) = (27._wp/60._wp)
-            coeff_L(1) = (47._wp/60._wp)
-            coeff_L(2) = (-13._wp/60._wp)
-            coeff_L(3) = (2._wp/60._wp)
-            !$acc update device(coeff_L)
-
-            @:ALLOCATE(coeff_R(-2:2))
-            coeff_R(2) = (-3._wp/60._wp)
-            coeff_R(1) = (27._wp/60._wp)
-            coeff_R(0) = (47._wp/60._wp)
-            coeff_R(-1) = (-13._wp/60._wp)
-            coeff_R(-2) = (2._wp/60._wp)
-            !$acc update device(coeff_R)
         end if
 
     end subroutine s_initialize_igr_module

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -898,8 +898,6 @@ contains
 
         integer :: pack_offset, unpack_offset
 
-        real(wp), pointer :: p_send, p_recv
-
 #ifdef MFC_MPI
 
         call nvtxStartRange("RHS-COMM-PACKBUF")
@@ -1100,11 +1098,8 @@ contains
         ! Send/Recv
         #:for rdma_mpi in [False, True]
             if (rdma_mpi .eqv. ${'.true.' if rdma_mpi else '.false.'}$) then
-                p_send => q_cons_buff_send(0)
-                p_recv => q_cons_buff_recv(0)
                 #:if rdma_mpi
-                    !$acc data attach(p_send, p_recv)
-                    !$acc host_data use_device(p_send, p_recv)
+                    !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                     call nvtxStartRange("RHS-COMM-SENDRECV-RDMA")
                 #:else
                     call nvtxStartRange("RHS-COMM-DEV2HOST")
@@ -1114,14 +1109,13 @@ contains
                 #:endif
 
                 call MPI_SENDRECV( &
-                    p_send, buffer_count, mpi_p, dst_proc, send_tag, &
-                    p_recv, buffer_count, mpi_p, src_proc, recv_tag, &
+                    q_cons_buff_send, buffer_count, mpi_p, dst_proc, send_tag, &
+                    q_cons_buff_recv, buffer_count, mpi_p, src_proc, recv_tag, &
                     MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                 call nvtxEndRange ! RHS-MPI-SENDRECV-(NO)-RDMA
 
                 #:if rdma_mpi
                     !$acc end host_data
-                    !$acc end data
                     !$acc wait
                 #:else
                     call nvtxStartRange("RHS-COMM-HOST2DEV")
@@ -2163,7 +2157,6 @@ contains
         integer, intent(IN) :: mpi_dir
         integer, intent(IN) :: pbc_loc
         integer :: i, j, k, l, r, q
-        real(wp), pointer :: p_send, p_recv
 
 #ifdef MFC_MPI
 
@@ -2182,20 +2175,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%end, 0, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%beg, 0, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr) 
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2221,20 +2210,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%beg, 1, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%beg, 0, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2277,20 +2262,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%beg, 1, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%end, 1, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2316,20 +2297,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%end, 0, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(n + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_x%end, 1, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2376,20 +2353,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%end, 0, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%beg, 0, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2414,20 +2387,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%beg, 1, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%beg, 0, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2470,20 +2439,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%beg, 1, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%end, 1, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2509,20 +2474,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%end, 0, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size + 1)*(p + 1), &
                         MPI_DOUBLE_PRECISION, bc_y%end, 1, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr) 
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait                        
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2568,20 +2529,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%end, 0, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%beg, 0, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2607,20 +2564,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%beg, 1, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%beg, 0, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)
@@ -2663,20 +2616,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%beg, 1, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%end, 1, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                         else
                         !$acc update host(q_cons_buff_send)
@@ -2701,20 +2650,16 @@ contains
                     end do
 
                     if(rdma_mpi) then 
-                        p_send => q_cons_buff_send(0)
-                        p_recv => q_cons_buff_recv(0)
-                        !$acc data attach(p_send, p_recv)
-                        !$acc host_data use_device(p_send, p_recv)
+                        !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                         call MPI_SENDRECV( &
-                        p_send, &
+                        q_cons_buff_send, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%end, 0, &
-                        p_recv, &
+                        q_cons_buff_recv, &
                         buff_size*(m + 2*buff_size+1)*(n + 2*buff_size +1), &
                         MPI_DOUBLE_PRECISION, bc_z%end, 1, &
                         MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
                         !$acc end host_data
-                        !$acc end data
                         !$acc wait 
                     else
                         !$acc update host(q_cons_buff_send)

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -88,6 +88,33 @@ contains
 
         integer :: i, j !< Generic loop iterators
 
+        integer :: vars_on_gpu = 0
+        character(len=10) :: vars_on_gpu_str
+
+#ifdef __NVCOMPILER_GPU_UNIFIED_MEM
+        call get_environment_variable("NVIDIA_VARS_ON_GPU", vars_on_gpu_str)
+
+        if (trim(vars_on_gpu_str) == "0") then
+            vars_on_gpu = 0
+        elseif (trim(vars_on_gpu_str) == "1") then
+            vars_on_gpu = 1
+        elseif (trim(vars_on_gpu_str) == "2") then
+            vars_on_gpu = 2
+        elseif (trim(vars_on_gpu_str) == "3") then
+            vars_on_gpu = 3
+        elseif (trim(vars_on_gpu_str) == "4") then
+            vars_on_gpu = 4
+        elseif (trim(vars_on_gpu_str) == "5") then
+            vars_on_gpu = 5
+        elseif (trim(vars_on_gpu_str) == "6") then
+            vars_on_gpu = 6
+        elseif (trim(vars_on_gpu_str) == "7") then
+            vars_on_gpu = 7
+        else ! default
+            vars_on_gpu = 0
+        endif
+#endif
+
         ! Setting number of time-stages for selected time-stepping scheme
         if (time_stepper == 1) then
             num_ts = 1
@@ -111,7 +138,9 @@ contains
                         idwbuff(2)%beg:idwbuff(2)%end, &
                         idwbuff(3)%beg:idwbuff(3)%end))
                         if ( i == 1 ) then
-                            @:PREFER_GPU(q_cons_ts(1)%vf(j)%sf)
+                            if ( j <= vars_on_gpu ) then
+                                @:PREFER_GPU(q_cons_ts(1)%vf(j)%sf)
+                            end if
                         end if
                 end do
                 @:ACC_SETUP_VFs_IGR(q_cons_ts(i))

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -97,9 +97,11 @@ contains
 
         ! Allocating the cell-average conservative variables
         @:ALLOCATE(q_cons_ts(1:num_ts))
+        @:PREFER_GPU(q_cons_ts)
 
         do i = 1, num_ts
             @:ALLOCATE(q_cons_ts(i)%vf(1:sys_size))
+            @:PREFER_GPU(q_cons_ts(i)%vf)
         end do
 
         if(igr) then 
@@ -108,6 +110,9 @@ contains
                     @:ALLOCATE(q_cons_ts(i)%vf(j)%sf(idwbuff(1)%beg:idwbuff(1)%end, &
                         idwbuff(2)%beg:idwbuff(2)%end, &
                         idwbuff(3)%beg:idwbuff(3)%end))
+                        if ( i == 1 ) then
+                            @:PREFER_GPU(q_cons_ts(1)%vf(j)%sf)
+                        end if
                 end do
                 @:ACC_SETUP_VFs_IGR(q_cons_ts(i))
                 allocate(q_cons_ts(i)%vf(sys_size)%sf(idwbuff(1)%beg:idwbuff(1)%end, &
@@ -301,6 +306,7 @@ contains
         else
             ! Allocating the cell-average RHS variables
             @:ALLOCATE(rhs_vf(1:sys_size))
+            @:PREFER_GPU(rhs_vf)
 
             if(.not. igr) then 
                 do i = 1, sys_size 
@@ -312,6 +318,7 @@ contains
                     @:ALLOCATE(rhs_vf(i)%sf(idwbuff(1)%beg:idwbuff(1)%end &
                     , idwbuff(2)%beg:idwbuff(2)%end, idwbuff(3)%beg:idwbuff(3)%end))
                     @:ACC_SETUP_SFs(rhs_vf(i))
+                    @:PREFER_GPU(rhs_vf(i)%sf)
                 end do
                 allocate(rhs_vf(sys_size)%sf(idwbuff(1)%beg:idwbuff(1)%end &
                     , idwbuff(2)%beg:idwbuff(2)%end, idwbuff(3)%beg:idwbuff(3)%end))
@@ -694,6 +701,7 @@ contains
             call s_update_lagrange_tdv_rk(stage=1)
         end if
 
+#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
         !$acc parallel loop collapse(3) gang vector default(present)
         do l = 0, p
             do k = 0, n
@@ -706,6 +714,22 @@ contains
                 end do
             end do
         end do
+#else
+        !$acc parallel loop collapse(3) gang vector default(present)
+        do l = 0, p
+            do k = 0, n
+                do j = 0, m
+                    do i = 1, vec_size
+                        q_cons_ts(2)%vf(i)%sf(j, k, l) = &
+                            q_cons_ts(1)%vf(i)%sf(j, k, l)
+                        q_cons_ts(1)%vf(i)%sf(j, k, l) = &
+                            q_cons_ts(1)%vf(i)%sf(j, k, l) &
+                            + dt*rhs_vf(i)%sf(j, k, l)
+                    end do
+                end do
+            end do
+        end do
+#endif
 
         !Evolve pb and mv for non-polytropic qbmm
         if (qbmm .and. (.not. polytropic)) then
@@ -762,13 +786,18 @@ contains
 
         ! Stage 2 of 3
 
+#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
         call s_compute_rhs(q_cons_ts(2)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
+#else
+        call s_compute_rhs(q_cons_ts(1)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
+#endif
 
         if (bubbles_lagrange) then
             call s_compute_EL_coupled_solver(q_cons_ts(2)%vf, q_prim_vf, rhs_vf, stage=2)
             call s_update_lagrange_tdv_rk(stage=2)
         end if
 
+#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
         !$acc parallel loop collapse(3) gang vector default(present)
         do l = 0, p
             do k = 0, n
@@ -782,6 +811,21 @@ contains
                 end do
             end do
         end do
+#else
+        !$acc parallel loop collapse(3) gang vector default(present)
+        do l = 0, p
+            do k = 0, n
+                do j = 0, m
+                    do i = 1, vec_size
+                        q_cons_ts(1)%vf(i)%sf(j, k, l) = &
+                            (3._wp*q_cons_ts(2)%vf(i)%sf(j, k, l) &
+                             + q_cons_ts(1)%vf(i)%sf(j, k, l) &
+                             + dt*rhs_vf(i)%sf(j, k, l))/4._wp
+                    end do
+                end do
+            end do
+        end do
+#endif
 
         if (qbmm .and. (.not. polytropic)) then
             !$acc parallel loop collapse(5) gang vector default(present)
@@ -838,13 +882,18 @@ contains
         end if
 
         ! Stage 3 of 3
+#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
         call s_compute_rhs(q_cons_ts(2)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
+#else
+        call s_compute_rhs(q_cons_ts(1)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
+#endif
 
         if (bubbles_lagrange) then
             call s_compute_EL_coupled_solver(q_cons_ts(2)%vf, q_prim_vf, rhs_vf, stage=3)
             call s_update_lagrange_tdv_rk(stage=3)
         end if
         
+#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
         !$acc parallel loop collapse(3) gang vector default(present)
         do l = 0, p
             do k = 0, n
@@ -858,6 +907,21 @@ contains
                 end do
             end do
         end do
+#else
+        !$acc parallel loop collapse(3) gang vector default(present)
+        do l = 0, p
+            do k = 0, n
+                do j = 0, m
+                    do i = 1, vec_size
+                        q_cons_ts(1)%vf(i)%sf(j, k, l) = &
+                            (q_cons_ts(2)%vf(i)%sf(j, k, l) &
+                             + 2._wp*q_cons_ts(1)%vf(i)%sf(j, k, l) &
+                             + 2._wp*dt*rhs_vf(i)%sf(j, k, l))/3._wp
+                    end do
+                end do
+            end do
+        end do
+#endif
 
         if (qbmm .and. (.not. polytropic)) then
             !$acc parallel loop collapse(5) gang vector default(present)

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -64,6 +64,9 @@ class MFCTarget:
         # The install directory is located <root>/build/install/<slug>
         return os.sep.join([os.getcwd(), "build", "install", self.get_slug(case)])
 
+    def get_home_dirpath(self, case: Case) -> str:
+        return os.sep.join([os.getcwd()])
+
     def get_install_binpath(self, case: Case ) -> str:
         # <root>/install/<slug>/bin/<target>
         return os.sep.join([self.get_install_dirpath(case), "bin", self.name])

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -82,5 +82,5 @@ n-gpu penguin/openmpi/4.1.5/nvhpc-22.3 nvidia/nvhpc/22.3 cuda/cuda-11.6
 n-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 san   CSCS Santis
-san-all cmake/3.30.5 python/3.12.5
-san-gpu nvhpc/24.11 cuda/12.6.0 cray-mpich/8.1.30
+san-all cmake python
+san-gpu nvhpc cuda cray-mpich

--- a/toolchain/templates/santis.mako
+++ b/toolchain/templates/santis.mako
@@ -57,7 +57,7 @@ echo
 
 % for target in targets:
     ${helpers.run_prologue(target)}
-
+    ${target.get_home_dirpath(case)}
     % if not mpi:
         (set -x; ${profiler} "${target.get_install_binpath(case)}")
     % else:
@@ -70,9 +70,9 @@ echo
             % endif
                 --wait 200 --bcast=/tmp/${target.name}               \
             % if target.name == 'simulation':
-                ../../misc/nvidia_uvm/nsys.sh                        \
+                "${target.get_home_dirpath(case)}/misc/nvidia_uvm/nsys.sh"                        \
             % endif
-                ../../misc/nvidia_uvm/bind.sh "${target.get_install_binpath(case)}")
+                "${target.get_home_dirpath(case)}/misc/nvidia_uvm/bind.sh" "${target.get_install_binpath(case)}")
     % endif
 
     ${helpers.run_epilogue(target)}

--- a/toolchain/templates/santis.mako
+++ b/toolchain/templates/santis.mako
@@ -63,7 +63,7 @@ echo
     % else:
         (set -x; srun \
                 --ntasks=${nodes*tasks_per_node}                     \
-                --cpus-per-task 9                                    \
+                --cpus-per-task 1                                    \
                 --cpu-bind=none                                      \
             % if gpu:
                 --gpus-per-task 1                                    \

--- a/toolchain/templates/santis.mako
+++ b/toolchain/templates/santis.mako
@@ -3,16 +3,13 @@
 <%namespace name="helpers" file="helpers.mako"/>
 
 % if engine == 'batch':
-#SBATCH --uenv=prgenv-nvfortran/24.11:v1@daint
+#SBATCH --uenv=icon/25.2:v1
 #SBATCH --nodes=${nodes}
-#SBATCH --ntasks=${nodes*tasks_per_node}
+#SBATCH --ntasks-per-node=${tasks_per_node}
 #SBATCH --job-name="${name}"
 #SBATCH --output="${name}.out"
+#SBATCH --error="${name}.err"
 #SBATCH --time=${walltime}
-% if gpu:
-#SBATCH --gpus-per-task=1
-#SBATCH --gpu-bind=closest
-% endif
 % if account:
 #SBATCH --account=${account}
 % endif
@@ -28,11 +25,25 @@
 % endif
 % endif
 
-export MPICH_GPU_SUPPORT_ENABLED=1
-export FI_CXI_RX_MATCH_MODE=software
-export FI_MR_CACHE_MONITOR=disabled
-export MPICH_NO_BUFFER_ALIAS_CHECK=1
+# NVHPC and CUDA env vars
+export NV_ACC_USE_MALLOC=1                    # use malloc instead of cudaMallocManaged ( compiled using -gpu=mem:unified )
+export NVCOMPILER_ACC_NO_MEMHINTS=1           # disable implicit compiler hints
+export CUDA_BUFFER_PAGE_IN_THRESHOLD_MS=0.001 # workaround for copying to/from unpopulated buffers on GH
 
+# Cray MPICH
+export MPICH_GPU_SUPPORT_ENABLED=1            # MPICH with GPU support
+export FI_CXI_RX_MATCH_MODE=software
+#export FI_MR_CACHE_MONITOR=disabled
+
+# CUSTOM env vars to MFC
+export NVIDIA_ALLOC_MODE=2                    # default alloc to prefloc CPU
+export NVIDIA_MANUAL_GPU_HINTS=1              # prefloc GPU on some
+export NVIDIA_IGR_TEMPS_ON_GPU=1              # jac on GPU and jac_rhs on CPU       ( NOTE: good default, tune based on size )
+export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on GPU ( NOTE: good default, tune based on size )
+
+# NSYS
+export NSYS=0                                 # enable nsys profiling
+export NSYS_FILE=myreport.qdrep
 
 ${helpers.template_prologue()}
 
@@ -51,14 +62,17 @@ echo
         (set -x; ${profiler} "${target.get_install_binpath(case)}")
     % else:
         (set -x; srun \
-        % if engine == 'interactive':
-                --nodes ${nodes} --ntasks-per-node ${tasks_per_node} \
-                --cpus-per-task 7                                    \
+                --ntasks=${nodes*tasks_per_node}                     \
+                --cpus-per-task 9                                    \
+                --cpu-bind=none                                      \
             % if gpu:
-                --gpus-per-task 1 --gpu-bind closest                 \
+                --gpus-per-task 1                                    \
             % endif
-        % endif
-                --wait 200 --bcast=/tmp/${target.name} ${profiler} "${target.get_install_binpath(case)}")
+                --wait 200 --bcast=/tmp/${target.name}               \
+            % if target.name == 'simulation':
+                ../../misc/nvidia_uvm/nsys.sh                        \
+            % endif
+                ../../misc/nvidia_uvm/bind.sh "${target.get_install_binpath(case)}")
     % endif
 
     ${helpers.run_epilogue(target)}


### PR DESCRIPTION
## Description

This PR introduces a set of changes that allow MFC to efficiently run out-of-core on NVIDIA Grace-Hopper using Unified Memory. 
It is developed in the context of the preparation of MFC for the Gordon Bell runs on ALPS supercomputer at CSCS.

Tested on Santis at CSCS using NVHPC 25.1 ( uenv `icon/25.2:v1` ) on `3D_IGR_perf_test` for various sizes N, with single and double precision, and with separate and unified memory modes.

Briefly, this PR:
- Fixes the `rdma_mpi` paths for IGR on Santis ( benefits both separate and unified memory builds )
- Uses `acc capture` to allocate the send and receive buffers on the GPU, allowing doing MPI send/recv directly from the GPU for the unified memory build.
- Makes `coeff_L` and `coeff_R` compile-time arrays.
- Implements an efficient and minimally intrusive out-of-core strategy based on Unified Memory, making good use of Grace-Hopper.
- Integrates the changes in the MFC runscripts.

In `misc/nvidia_uvm/README.md`, there is a brief explanation of the out-of-core strategy, along with an example workflow and some relevant scripts and environment variables that need to be set.