### PR TITLE
Frontier Unified memory implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,13 @@ function(MFC_SETUP_TARGET)
                     )
                 endif()
             elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+	    # Frontier Unified Memory Support
+                if (MFC_Unified)
+                    target_compile_options(${ARGS_TARGET}
+                        PRIVATE -DFRONTIER_UNIFIED
+                    )
+                endif()
+
                 find_package(hipfort COMPONENTS hip CONFIG REQUIRED)
                 target_link_libraries(${a_target} PRIVATE hipfort::hip hipfort::hipfort-amdgcn)
             endif()

--- a/src/simulation/m_igr.fpp
+++ b/src/simulation/m_igr.fpp
@@ -33,7 +33,10 @@ module m_igr
     real(wp), allocatable, dimension(:, :) :: Res
     !$acc declare create(Res)
 
-
+#ifdef _CRAYFTN
+    real(wp), allocatable, dimension(:) :: coeff_L, coeff_R
+    !$acc declare create(coeff_L, coeff_R)
+#else
     real(wp), parameter :: coeff_L(-1:3) = [ &
         -3._wp/60._wp,   &  ! Index -1
         27._wp/60._wp,   &  ! Index 0
@@ -49,6 +52,7 @@ module m_igr
         27._wp/60._wp,   &  ! Index 1
         -3._wp/60._wp    &  ! Index 2
         ]
+#endif
 
     integer :: i, j, k, l, q, r
 
@@ -116,7 +120,23 @@ contains
                    end do
                 end do
             end do
+#ifdef _CRAYFTN
+            @:ALLOCATE(coeff_L(-1:3))
+            coeff_L(-1) = (-3._wp/60._wp)
+            coeff_L(0) = (27._wp/60._wp)
+            coeff_L(1) = (47._wp/60._wp)
+            coeff_L(2) = (-13._wp/60._wp)
+            coeff_L(3) = (2._wp/60._wp)
+            !$acc update device(coeff_L)
 
+            @:ALLOCATE(coeff_R(-2:2))
+            coeff_R(2) = (-3._wp/60._wp)
+            coeff_R(1) = (27._wp/60._wp)
+            coeff_R(0) = (47._wp/60._wp)
+            coeff_R(-1) = (-13._wp/60._wp)
+            coeff_R(-2) = (2._wp/60._wp)
+            !$acc update device(coeff_R)
+#endif
         end if
 
     end subroutine s_initialize_igr_module

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -1456,7 +1456,7 @@ contains
                 open (1, file='memory_usage_data.dat', position='append', status='old')
             else
                 open (1, file='memory_usage_data.dat', status='new')
-                write (1, '(A15, A15, A15, A15, A15)') "Ranks", "CPU Current", "CPU Peak", "GPU Current", "GPU Free"
+                write (1, '(A15, A15, A15, A17, A17)') "Ranks", "CPU Current", "CPU Peak", "GPU Current", "GPU Free"
             end if
             call s_read_cpu_memory_usage(cpu_current, cpu_peak)
             gpu_current_kb = 0.0
@@ -1466,11 +1466,11 @@ contains
             gpu_current_kb = (real(gpu_total) - real(gpu_free)) / 1024.
             gpu_free_kb = real(gpu_free) / 1024.
 #endif
-            write (gpu_current_str, '(F13.2)') gpu_current_kb
+            write (gpu_current_str, '(F15.2)') gpu_current_kb
 	    gpu_current_str = trim(gpu_current_str) // "kB"
-            write (gpu_free_str, '(F13.2)') gpu_free_kb
+            write (gpu_free_str, '(F15.2)') gpu_free_kb
             gpu_free_str = trim(gpu_free_str) // "kB"
-            write (1, '(I15, A15, A15, A15, A15)') num_procs, trim(cpu_current), trim(cpu_peak), gpu_current_str, gpu_free_str
+            write (1, '(I15, A15, A15, A17, A17)') num_procs, trim(cpu_current), trim(cpu_peak), gpu_current_str, gpu_free_str
             close (1)
             
         end if

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -163,6 +163,7 @@ contains
 
 	   ! CCE see it can access this and will leave it on the host. It will stay on the host so long as HSA_XNACK=1
 	   ! NOTE: WE CANNOT DO ATOMICS INTO THIS MEMORY. We have to change a property to use atomics here
+	   ! Otherwise leaving this as fine-grained will actually help performance since it can't be cached in GPU L2
 	   call hipCheck(hipMallocManaged(q_cons_ts_pool_host, dims=pool_dims, lbounds=pool_starts, flags=hipMemAttachGlobal))
 
            do j = 1, sys_size
@@ -1465,7 +1466,9 @@ contains
         @:DEALLOCATE(q_cons_ts)
 #ifdef FRONTIER_UNIFIED
         call hipCheck(hipHostFree(q_cons_ts_pool_host))
-	call acc_unmap_data(q_cons_ts_pool_device)
+	! I thought we would want to unmap to be clean, but
+	! this gives a present table error so don't bother.
+	!call acc_unmap_data(q_cons_ts_pool_device)
 	call hipCheck(hipFree(q_cons_ts_pool_device))
 #endif
         ! Deallocating the cell-average primitive ts variables

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -79,13 +79,23 @@ module m_time_steppers
 
     !$acc declare create(q_cons_ts, q_prim_vf, q_T_sf, rhs_vf, rhs_ts_rkck, q_prim_ts, rhs_mv, rhs_pb, max_dt)
 
+#ifdef FRONTIER_UNIFIED
+   real(wp), pointer, contiguous, dimension(:,:,:,:) :: q_cons_ts_pool_host, q_cons_ts_pool_device
+   integer :: pool_dims(4), pool_starts(4)
+#endif
+      
 contains
 
     !> The computation of parameters, the allocation of memory,
         !!      the association of pointers and/or the execution of any
         !!      other procedures that are necessary to setup the module.
     subroutine s_initialize_time_steppers_module
-
+#ifdef FRONTIER_UNIFIED
+        use hipfort
+        use hipfort_hipmalloc
+        use hipfort_check
+	use openacc
+#endif
         integer :: i, j !< Generic loop iterators
 
         integer :: vars_on_gpu = 0
@@ -132,7 +142,48 @@ contains
         end do
 
         if(igr) then 
-            do i = 1, num_ts
+#ifdef FRONTIER_UNIFIED
+           if (num_ts /= 2) stop "FRONTIER_UNIFIED assumes num_ts = 2"
+          !Allocate to memory regions using hip calls
+          ! that we will attach pointers to
+           do i=1,3
+              pool_dims(i) = idwbuff(i)%end - idwbuff(i)%beg + 1
+              pool_starts(i) = idwbuff(i)%beg
+           end do
+           pool_dims(4) = sys_size
+           pool_starts(4) = 1
+
+	   ! Doing hipMalloc then mapping should be most performant
+           call hipCheck(hipMalloc(q_cons_ts_pool_device, dims=pool_dims, lbounds=pool_starts))
+	   ! Without this map CCE will still create a device copy, because it's silly like that
+	   call acc_map_data(q_cons_ts_pool_device, c_loc(q_cons_ts_pool_device), c_sizeof(q_cons_ts_pool_device))
+
+	   ! If the hipMalloc route isn't working we could use this and them prefetch, if we need to
+           !!call hipCheck(hipMallocManaged(q_cons_ts_pool_device, dims=pool_dims, lbounds=pool_starts, flags=hipMemAttachGlobal))
+
+	   ! CCE see it can access this and will leave it on the host. It will stay on the host so long as HSA_XNACK=1
+	   ! NOTE: WE CANNOT DO ATOMICS INTO THIS MEMORY. We have to change a property to use atomics here
+	   call hipCheck(hipMallocManaged(q_cons_ts_pool_host, dims=pool_dims, lbounds=pool_starts, flags=hipMemAttachGlobal))
+
+           do j = 1, sys_size
+              ! q_cons_ts(1) lives on the device
+              q_cons_ts(1)%vf(j)%sf(idwbuff(1)%beg:idwbuff(1)%end, &
+                                        idwbuff(2)%beg:idwbuff(2)%end, &
+                                        idwbuff(3)%beg:idwbuff(3)%end) => q_cons_ts_pool_device(:,:,:,j)
+              ! q_cons_ts(2) lives on the host
+              q_cons_ts(2)%vf(j)%sf(idwbuff(1)%beg:idwbuff(1)%end, &
+                                        idwbuff(2)%beg:idwbuff(2)%end, &
+                                        idwbuff(3)%beg:idwbuff(3)%end) => q_cons_ts_pool_host(:,:,:,j)
+          end do
+          do i = 1, num_ts
+             @:ACC_SETUP_VFs_IGR(q_cons_ts(i))             
+            do j = 1, vec_size
+                !$acc update device(q_cons_ts(i)%vf(j))
+            enddo
+         end do
+
+#else
+           do i = 1, num_ts
                 do j = 1, vec_size
                     @:ALLOCATE(q_cons_ts(i)%vf(j)%sf(idwbuff(1)%beg:idwbuff(1)%end, &
                         idwbuff(2)%beg:idwbuff(2)%end, &
@@ -148,6 +199,7 @@ contains
                         idwbuff(2)%beg:idwbuff(2)%end, &
                         idwbuff(3)%beg:idwbuff(3)%end))
             end do
+#endif
         else 
             do i = 1, num_ts
                 do j = 1, sys_size 
@@ -738,7 +790,7 @@ contains
             call s_update_lagrange_tdv_rk(stage=1)
         end if
 
-#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
+#if !defined(__NVCOMPILER_GPU_UNIFIED_MEM) && !defined(FRONTIER_UNIFIED)
         !$acc parallel loop collapse(3) gang vector default(present)
         do l = 0, p
             do k = 0, n
@@ -823,7 +875,7 @@ contains
 
         ! Stage 2 of 3
 
-#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
+#if !defined(__NVCOMPILER_GPU_UNIFIED_MEM) && !defined(FRONTIER_UNIFIED)
         call s_compute_rhs(q_cons_ts(2)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
 #else
         call s_compute_rhs(q_cons_ts(1)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
@@ -834,7 +886,8 @@ contains
             call s_update_lagrange_tdv_rk(stage=2)
         end if
 
-#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
+
+#if  !defined(__NVCOMPILER_GPU_UNIFIED_MEM) && !defined(FRONTIER_UNIFIED)
         !$acc parallel loop collapse(3) gang vector default(present)
         do l = 0, p
             do k = 0, n
@@ -919,7 +972,7 @@ contains
         end if
 
         ! Stage 3 of 3
-#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
+#if !defined(__NVCOMPILER_GPU_UNIFIED_MEM) && !defined(FRONTIER_UNIFIED)
         call s_compute_rhs(q_cons_ts(2)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
 #else
         call s_compute_rhs(q_cons_ts(1)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(2)%sf, rhs_pb, mv_ts(2)%sf, rhs_mv, t_step, time_avg)
@@ -930,7 +983,7 @@ contains
             call s_update_lagrange_tdv_rk(stage=3)
         end if
         
-#ifndef __NVCOMPILER_GPU_UNIFIED_MEM
+#if !defined(__NVCOMPILER_GPU_UNIFIED_MEM) && !defined(FRONTIER_UNIFIED)
         !$acc parallel loop collapse(3) gang vector default(present)
         do l = 0, p
             do k = 0, n
@@ -1386,22 +1439,35 @@ contains
 
     !> Module deallocation and/or disassociation procedures
     subroutine s_finalize_time_steppers_module
+#ifdef FRONTIER_UNIFIED
+        use hipfort
+        use hipfort_hipmalloc
+        use hipfort_check
+#endif
 
         integer :: i, j !< Generic loop iterators
 
         ! Deallocating the cell-average conservative variables
         do i = 1, num_ts
-
+#ifdef FRONTIER_UNIFIED
+            do j = 1, vec_size
+                nullify(q_cons_ts(i)%vf(j)%sf)
+            end do
+#else
             do j = 1, vec_size
                 @:DEALLOCATE(q_cons_ts(i)%vf(j)%sf)
             end do
-
+#endif
             @:DEALLOCATE(q_cons_ts(i)%vf)
 
         end do
 
         @:DEALLOCATE(q_cons_ts)
-
+#ifdef FRONTIER_UNIFIED
+        call hipCheck(hipHostFree(q_cons_ts_pool_host))
+	call acc_unmap_data(q_cons_ts_pool_device)
+	call hipCheck(hipFree(q_cons_ts_pool_device))
+#endif
         ! Deallocating the cell-average primitive ts variables
         if (probe_wrt) then
             do i = 0, 3

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -81,10 +81,6 @@ else
     module purge > /dev/null 2>&1
 fi
 
-# FIXME - for Frontier, load Steve's private CCE install
-if [ "$u_c" == 'f' ]; then
-    module use /ccs/home/sabbott/soft/modulefiles/
-fi
 
 ELEMENTS="$(__extract "$u_c-all") $(__extract "$u_c-$cg")"
 MODULES=`echo "$ELEMENTS" | tr ' ' '\n' | grep -v = | xargs`

--- a/toolchain/mfc/run/run.py
+++ b/toolchain/mfc/run/run.py
@@ -46,10 +46,10 @@ def __profiler_prepend() -> typing.List[str]:
         return ["nsys", "profile", "--stats=true", "--trace=mpi,nvtx,openacc"] + ARG("nsys")
 
     if ARG("omni") is not None:
-        if not does_command_exist("omniperf"):
-            raise MFCException("Failed to locate [bold red]ROCM Omniperf[/bold red] (omniperf).")
+        if not does_command_exist("rocprof-compute"):
+            raise MFCException("Failed to locate [bold red]ROCM Omniperf[/bold red] (rocprof-compute).")
 
-        return ["omniperf", "profile"] + ARG("omni") + ["--"]
+        return ["rocprof-compute", "profile"] + ARG("omni") + ["--"]
 
     if ARG("roc") is not None:
         if not does_command_exist("rocprof"):

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -48,9 +48,9 @@ p-gpu nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
 p-gpu MFC_CUDA_CC=70,75,80,89,90 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier
-f-all cpe/24.11 rocm/6.3.1 cce/19.0.0 
+f-all cpe/25.03 rocm/6.3.1
 f-all cray-fftw cray-hdf5 cray-python
-f-gpu craype-accel-amd-gfx90a
+f-gpu craype-accel-amd-gfx90a rocprofiler-compute/3.0.0
 
 d     NCSA Delta
 d-all python/3.11.6

--- a/toolchain/templates/frontier.mako
+++ b/toolchain/templates/frontier.mako
@@ -42,6 +42,9 @@ echo
 
 export MPICH_GPU_SUPPORT_ENABLED=1
 
+# when compiled with --unified, keeps q_cons_ts(2) on the host and `q_cons_ts(1)` on the device
+export CRAY_ACC_USE_UNIFIED_MEM=1
+
 % for target in targets:
     ${helpers.run_prologue(target)}
 


### PR DESCRIPTION
These changes implement a version of the unified address space support on Frontier.

When built with `--unified`, `q_cons_ts(1)` will be backed by pure device memory and `q_cons_ts(2)` will be backed by host memory. This will always be _functionally correct_, but if you don't also run with `CRAY_ACC_USE_UNIFIED_MEM=1` set then both `q_cons_ts(1)` and `q_cons_ts(2)` will have new device arrays allocated for them by the runtime, actually increasing memory usage.

`frontier.mako` sets `CRAY_ACC_USE_UNIFIED_MEM=1` all the time now, which should be a negligible performance hit.

To verify this capability, and make tuning easier, I've also modified the performance data output to also write a file `memory_usage_data.dat` that will contain the CPU and GPU memory usage for rank 0. Here's a preview:

```
          Ranks    CPU Current       CPU Peak    GPU Current       GPU Free
              1      2959479kB      2965872kB     5478400.00kB    61614080.00kB
```

Right now the GPU numbers are predicated on `_CRAYFTN` being set but it would be trivial to have an NVIDIA ifdef that calls cudaMemGetInfo instead.

The CPU current and high water mark numbers are going to be weird, and probably a low ball from what's actually "allocated". Linux memory is a complicated thing, and our choices are basically "every piece of memory this process has ever touched, including files" or "only the pages we've actually initialized and wired". I chose the later, which means this number is going to be less than the total number of pages `allocated` because we often allocate pages and then never initialize them on the host. That should be okay, because generally CPU memory can often be oversubscribed a bit.

It's actually unclear if `hipMallocManaged` or `cudaMallocManaged` numbers will be included in the CPU memory count, now that I think about it... I suppose what I'm saying is trust the GPU number a lot and treat the CPU number as iffy.

Also includes assorted other toolchain fixes for Frontier, including using the system CCE 19.0.0. 