### PR TITLE
Modified Strategy for Running MFC out-of-core on NVIDIA Grace-Hopper using Unified Memory

### DIFF
--- a/misc/nvidia_uvm/nsys.sh
+++ b/misc/nvidia_uvm/nsys.sh
@@ -10,12 +10,11 @@ rank="${OMPI_COMM_WORLD_RANK:-$SLURM_PROCID}"
 
 if [[ "$NSYS" -ne 0 && "$rank" -eq 0 ]]; then
   exec nsys profile \
-      --cuda-um-cpu-page-faults true \
-      --cuda-um-gpu-page-faults true \
+       --cpuctxsw=none -b none -s none \
       --event-sample=system-wide \
       --cpu-socket-events=61,71,265,273 \
       --cpu-socket-metrics=103,104 \
-      --event-sampling-interval=1 \
+      --event-sampling-interval=10 \
       --trace=nvtx,openacc \
       --force-overwrite=true \
       -e NSYS_MPI_STORE_TEAMS_PER_RANK=1 \

--- a/toolchain/templates/santis.mako
+++ b/toolchain/templates/santis.mako
@@ -38,7 +38,7 @@ export FI_CXI_RX_MATCH_MODE=software
 # CUSTOM env vars to MFC
 export NVIDIA_ALLOC_MODE=0                    # do nothing
 export NVIDIA_MANUAL_GPU_HINTS=1              # prefloc GPU on some
-export NVIDIA_IGR_TEMPS_ON_GPU=3              # jac and jac_rhs on GPU and jac_old on CPU
+export NVIDIA_IGR_TEMPS_ON_GPU=3              # jac, jac_rhs, and jac_old on GPU
 export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on GPU
 
 # NSYS

--- a/toolchain/templates/santis.mako
+++ b/toolchain/templates/santis.mako
@@ -38,8 +38,8 @@ export FI_CXI_RX_MATCH_MODE=software
 # CUSTOM env vars to MFC
 export NVIDIA_ALLOC_MODE=0                    # do nothing
 export NVIDIA_MANUAL_GPU_HINTS=1              # prefloc GPU on some
-export NVIDIA_IGR_TEMPS_ON_GPU=1              # jac on GPU and jac_rhs on CPU       ( NOTE: good default, tune based on size )
-export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on GPU ( NOTE: good default, tune based on size )
+export NVIDIA_IGR_TEMPS_ON_GPU=3              # jac and jac_rhs on GPU and jac_old on CPU
+export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on GPU
 
 # NSYS
 export NSYS=0                                 # enable nsys profiling

--- a/toolchain/templates/santis.mako
+++ b/toolchain/templates/santis.mako
@@ -26,9 +26,9 @@
 % endif
 
 # NVHPC and CUDA env vars
-export NV_ACC_USE_MALLOC=1                    # use malloc instead of cudaMallocManaged ( compiled using -gpu=mem:unified )
+export NV_ACC_USE_MALLOC=0                    # use cudaMallocManaged instead of malloc ( compiled using -gpu=mem:unified )
 export NVCOMPILER_ACC_NO_MEMHINTS=1           # disable implicit compiler hints
-export CUDA_BUFFER_PAGE_IN_THRESHOLD_MS=0.001 # workaround for copying to/from unpopulated buffers on GH
+#export CUDA_BUFFER_PAGE_IN_THRESHOLD_MS=0.001 # workaround for copying to/from unpopulated buffers on GH
 
 # Cray MPICH
 export MPICH_GPU_SUPPORT_ENABLED=1            # MPICH with GPU support
@@ -36,7 +36,7 @@ export FI_CXI_RX_MATCH_MODE=software
 #export FI_MR_CACHE_MONITOR=disabled
 
 # CUSTOM env vars to MFC
-export NVIDIA_ALLOC_MODE=2                    # default alloc to prefloc CPU
+export NVIDIA_ALLOC_MODE=0                    # do nothing
 export NVIDIA_MANUAL_GPU_HINTS=1              # prefloc GPU on some
 export NVIDIA_IGR_TEMPS_ON_GPU=1              # jac on GPU and jac_rhs on CPU       ( NOTE: good default, tune based on size )
 export NVIDIA_VARS_ON_GPU=7                   # q_cons_ts(1)%vf%sf for j=1-7 on GPU ( NOTE: good default, tune based on size )


### PR DESCRIPTION
## Description

This PR builds on top of the work done in #5 and #7, and aims to improve the existing out-of-core strategy for the Gordon Bell run of MFC on ALPS supercomputer.

It overrides the previous out-of-core strategy with a modified version that relies on `cudaMallocManaged` and `pinned` memory pools for the data that will live on the CPU.

With this approach we workaround the regression we hit with the previous approach ( malloc-based ) and boost performance substantially.

In this approach `q_cons_ts(2)` is always physically backed on the CPU, and the physical backing of `jac`, `jac_rhs`, and `jac_old` can be configured by setting accordingly the environment variable `NVIDIA_IGR_TEMPS_ON_GPU` to `1`, `2`, or `3`.

The rest environment variables should be set as in `toolchain/templates/santis.mako` and should not be changed.


